### PR TITLE
"Fails" less

### DIFF
--- a/NadekoInstaller.bat
+++ b/NadekoInstaller.bat
@@ -38,7 +38,7 @@ IF EXIST "%root%NadekoBot\" (GOTO :backupinstall)
 :freshinstall
 	::Moves the NadekoBot folder to keep things tidy
 	ROBOCOPY "%root%NadekoInstall_Temp" "%rootdir%" /E /MOVE >nul 2>&1
-	IF %ERRORLEVEL% NEQ 0 (IF %ERRORLEVEL% NEQ 1 (IF %ERRORLEVEL% NEQ 3 GOTO :copyerror))
+	IF %ERRORLEVEL% GEQ 8 (GOTO :copyerror)
 	GOTO :end
 :backupinstall
 	TITLE Backing up old files
@@ -47,26 +47,26 @@ IF EXIST "%root%NadekoBot\" (GOTO :backupinstall)
 	PAUSE >nul 2>&1
 	::Recursively copies all files and folders from NadekoBot to NadekoBot_Old
 	ROBOCOPY "%root%NadekoBot" "%root%NadekoBot_Old" /MIR >nul 2>&1
-	IF %ERRORLEVEL% NEQ 0 (IF %ERRORLEVEL% NEQ 1 (IF %ERRORLEVEL% NEQ 3 GOTO :copyerror))
+	IF %ERRORLEVEL% GEQ 8 (GOTO :copyerror)
 	ECHO.
 	ECHO Old files backed up to NadekoBot_Old
 	::Copies the credentials and database from the backed up data to the new folder
 	COPY "%root%NadekoBot_Old\src\NadekoBot\credentials.json" "%installtemp%NadekoBot\src\NadekoBot\credentials.json" >nul 2>&1
-	IF %ERRORLEVEL% NEQ 0 (IF %ERRORLEVEL% NEQ 1 (IF %ERRORLEVEL% NEQ 3 GOTO :copyerror))
+	IF %ERRORLEVEL% GEQ 8 (GOTO :copyerror)
 	ECHO.
 	ECHO credentials.json copied to new folder
 	ROBOCOPY "%root%NadekoBot_Old\src\NadekoBot\bin" "%installtemp%NadekoBot\src\NadekoBot\bin" /E >nul 2>&1
-	IF %ERRORLEVEL% NEQ 0 (IF %ERRORLEVEL% NEQ 1 (IF %ERRORLEVEL% NEQ 3 GOTO :copyerror))
+	IF %ERRORLEVEL% GEQ 8 (GOTO :copyerror)
 	ECHO.
 	ECHO Old bin folder copied to new folder
 	ROBOCOPY "%root%NadekoBot_Old\src\NadekoBot\data" "%installtemp%NadekoBot\src\NadekoBot\data" /E >nul 2>&1
-	IF %ERRORLEVEL% NEQ 0 (IF %ERRORLEVEL% NEQ 1 (IF %ERRORLEVEL% NEQ 3 GOTO :copyerror))
+	IF %ERRORLEVEL% GEQ 8 (GOTO :copyerror)
 	ECHO.
 	ECHO Old data folder copied to new folder
 	::Moves the setup Nadeko folder
 	RMDIR "%root%NadekoBot\" /S /Q >nul 2>&1
 	ROBOCOPY "%root%NadekoInstall_Temp" "%rootdir%" /E /MOVE >nul 2>&1
-	IF %ERRORLEVEL% NEQ 0 (IF %ERRORLEVEL% NEQ 1 (IF %ERRORLEVEL% NEQ 3 GOTO :copyerror))
+	IF %ERRORLEVEL% GEQ 8 (GOTO :copyerror)
 	GOTO :end
 :dotnet
 	::Terminates the batch script if it can't run dotnet --version

--- a/NadekoInstaller.bat
+++ b/NadekoInstaller.bat
@@ -93,9 +93,9 @@ IF EXIST "%root%NadekoBot\" (GOTO :backupinstall)
 	::If at any point a copy error is encountered 
 	TITLE Error!
 	ECHO.
-	ECHO An error in copying data has been encountered.
+	ECHO An error in copying data has been encountered, returning an exit code of %ERRORLEVEL%
 	ECHO.
-	ECHO Make sure to close any files, such as `NadekoBot.db` before continuing
+	ECHO Make sure to close any files, such as `NadekoBot.db` before continuing or try running the installer as an Administrator
 	PAUSE >nul 2>&1
 	CD /D "%root%"
 	GOTO :EOF


### PR DESCRIPTION
less restrictive on what "errors" robocopy is allowed to output, now only stops if ROBOCOPY exits with the "FAIL" exit code ¯\_(ツ)_/¯

Also returns an exit code so people can either come to us complaining in the hope that someone who knows robocopy is on, or they can be handy and search themselves 